### PR TITLE
Add missed `parser: babel-eslint` to eslint config

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = {
     commonjs: true,
     es6: true,
   },
+  parser: 'babel-eslint',
   rules: {
     strict: 0,
     'max-len': [2, {


### PR DESCRIPTION
Without it we can't, for example, use decorators in [react config](https://github.com/appbooster/eslint-config-react)