### PR TITLE
Do not require empty line after single-line class member

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,5 +23,6 @@ module.exports = {
     'no-plusplus': ['off'],
     'consistent-return': ['off'],
     'newline-before-return': 'error',
+    'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
   },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appbooster/eslint-config-base",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Appbooster's ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Делаем пустую строку необязательной после однострочных объявлений в классе, например

```js
@observable something = 15
@observable somethingElse = 20
```